### PR TITLE
Add retry logic to heartbeat/registration loops

### DIFF
--- a/packages/dffmpeg-client/src/dffmpeg/client/api.py
+++ b/packages/dffmpeg-client/src/dffmpeg/client/api.py
@@ -1,12 +1,12 @@
 import asyncio
 import logging
-import random
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from ulid import ULID
 
 from dffmpeg.client.config import ClientConfig
 from dffmpeg.common.http_client import AuthenticatedAsyncClient
+from dffmpeg.common.loop_utils import heartbeat_loop
 from dffmpeg.common.models import (
     CommandResponse,
     JobLogsMessage,
@@ -169,28 +169,26 @@ class DFFmpegClient:
 
     async def _heartbeat_loop(self, job_id: str, interval: int):
         """Periodically sends client heartbeats to the coordinator."""
-        # Use jitter logic similar to worker
-        jitter_bound = min(0.5 * interval, 0.5)  # Max 0.5s jitter for client
-        first_loop = True
-        while self._monitoring:
-            try:
-                if not first_loop:
-                    # Sleep with jitter before subsequent heartbeats
-                    jitter = random.uniform(-jitter_bound, jitter_bound)
-                    await asyncio.sleep(max(1, interval + jitter))
+        path = f"/jobs/{job_id}/client_heartbeat"
 
-                first_loop = False
+        async def _action():
+            resp = await self.client.post(path)
+            logger.debug(f"[{self.config.client_id}] Sent heartbeat for {job_id}")
+            if resp.status_code != 200:
+                logger.warning(f"Client heartbeat failed: {resp.status_code} - {resp.text}")
+                resp.raise_for_status()
 
-                path = f"/jobs/{job_id}/client_heartbeat"
-                resp = await self.client.post(path)
-                if resp.status_code != 200:
-                    logger.warning(f"Client heartbeat failed: {resp.status_code} - {resp.text}")
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.error(f"Error in client heartbeat loop: {e}")
-                # Ensure we don't rapid-fire on exception if it happened before the sleep
-                first_loop = False
+        # Max 0.5s jitter for client
+        jitter_bound = min(0.5 * interval, 0.5)
+
+        await heartbeat_loop(
+            name="client heartbeat",
+            action=_action,
+            is_running=lambda: getattr(self, "_monitoring", False),
+            interval=float(interval),
+            jitter_bound=jitter_bound,
+            first_immediate=True,
+        )
 
     async def stream_job(
         self, job_id: str, transport_name: str, transport_metadata: Dict[str, Any]

--- a/packages/dffmpeg-common/src/dffmpeg/common/loop_utils.py
+++ b/packages/dffmpeg-common/src/dffmpeg/common/loop_utils.py
@@ -1,0 +1,64 @@
+import asyncio
+import logging
+import random
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+async def async_retry(
+    func: Callable[[], Awaitable[Any]],
+    max_sleep: float,
+    initial_delay: float = 1.0,
+    multiplier: float = 2.0,
+) -> Any:
+    """
+    Retries an async function with exponential backoff until the next delay
+    is >= the max_sleep. If that happens, raises the last exception.
+    """
+    delay = initial_delay
+    while True:
+        try:
+            return await func()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            if delay >= max_sleep:
+                raise e
+            logger.debug(f"Retrying after {delay}s due to error: {e}")
+            await asyncio.sleep(delay)
+            delay *= multiplier
+
+
+async def heartbeat_loop(
+    name: str,
+    action: Callable[[], Awaitable[Any]],
+    is_running: Callable[[], bool],
+    interval: float,
+    jitter_bound: float,
+    first_immediate: bool = False,
+    retry_initial_delay: float = 1.0,
+) -> None:
+    """
+    A generic loop for periodic background actions (like heartbeats).
+    """
+    first_loop = True
+    while is_running():
+        try:
+            if not first_loop or not first_immediate:
+                jitter = random.uniform(-jitter_bound, jitter_bound)
+                await asyncio.sleep(max(1.0, interval + jitter))
+
+            first_loop = False
+
+            # Use retry logic for the action. max_sleep is the interval so retries don't exceed the loop cycle length.
+            await async_retry(func=action, max_sleep=interval, initial_delay=retry_initial_delay)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Error in {name} loop: {e}")
+            # Ensure we don't rapid-fire on exception
+            if first_loop:
+                # Means we errored before we set this to False, somehow
+                first_loop = False

--- a/packages/dffmpeg-common/tests/unit/test_loop_utils.py
+++ b/packages/dffmpeg-common/tests/unit/test_loop_utils.py
@@ -1,0 +1,164 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dffmpeg.common.loop_utils import async_retry, heartbeat_loop
+
+
+@pytest.mark.asyncio
+async def test_async_retry_success_first_try():
+    mock_func = AsyncMock(return_value="success")
+
+    result = await async_retry(mock_func, max_sleep=10.0)
+
+    assert result == "success"
+    mock_func.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_retry_success_after_retries():
+    # Fail twice, succeed on third
+    mock_func = AsyncMock(side_effect=[ValueError("fail 1"), ValueError("fail 2"), "success"])
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await async_retry(mock_func, max_sleep=10.0, initial_delay=1.0, multiplier=2.0)
+
+        assert result == "success"
+        assert mock_func.call_count == 3
+        # Should have slept for 1.0, then 2.0
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(1.0)
+        mock_sleep.assert_any_call(2.0)
+
+
+@pytest.mark.asyncio
+async def test_async_retry_exceeds_max_sleep():
+    mock_func = AsyncMock(side_effect=ValueError("persistent fail"))
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        # Initial delay 2.0, max_sleep 3.0
+        # Attempt 1: fails, delay 2.0 < 3.0 -> sleep(2.0), new delay = 4.0
+        # Attempt 2: fails, delay 4.0 >= 3.0 -> raises Error
+        with pytest.raises(ValueError, match="persistent fail"):
+            await async_retry(mock_func, max_sleep=3.0, initial_delay=2.0, multiplier=2.0)
+
+        assert mock_func.call_count == 2
+        mock_sleep.assert_called_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_async_retry_cancelled():
+    mock_func = AsyncMock(side_effect=asyncio.CancelledError("cancelled"))
+
+    with pytest.raises(asyncio.CancelledError):
+        await async_retry(mock_func, max_sleep=10.0)
+
+    assert mock_func.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_basic():
+    action = AsyncMock()
+
+    # We want the loop to run twice and then stop
+    run_state = [True, True, False]
+
+    def is_running():
+        return run_state.pop(0)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        # We patch random.uniform to control the jitter
+        with patch("random.uniform", return_value=0.1):
+            await heartbeat_loop(
+                name="test",
+                action=action,
+                is_running=is_running,
+                interval=5.0,
+                jitter_bound=0.5,
+                first_immediate=False,
+            )
+
+    # first iteration: sleep(5.1), action()
+    # second iteration: sleep(5.1), action()
+    assert action.call_count == 2
+    assert mock_sleep.call_count == 2
+    mock_sleep.assert_called_with(5.1)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_first_immediate():
+    action = AsyncMock()
+
+    # We want the loop to run twice and then stop
+    run_state = [True, True, False]
+
+    def is_running():
+        return run_state.pop(0)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        with patch("random.uniform", return_value=0.1):
+            await heartbeat_loop(
+                name="test",
+                action=action,
+                is_running=is_running,
+                interval=5.0,
+                jitter_bound=0.5,
+                first_immediate=True,
+            )
+
+    assert action.call_count == 2
+    # Sleep should only be called once because first_immediate skips the sleep on the first loop
+    assert mock_sleep.call_count == 1
+    mock_sleep.assert_called_with(5.1)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_action_raises():
+    # If the action raises an exception that async_retry lets bubble up
+    # (e.g. because max_sleep is exceeded immediately), heartbeat_loop catches it and logs it.
+    action = AsyncMock(side_effect=ValueError("action failed"))
+
+    run_state = [True, False]
+
+    def is_running():
+        return run_state.pop(0)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        with patch("dffmpeg.common.loop_utils.logger") as mock_logger:
+            await heartbeat_loop(
+                name="test",
+                action=action,
+                is_running=is_running,
+                interval=1.0,  # This acts as max_sleep in async_retry
+                jitter_bound=0.5,
+                first_immediate=True,
+                retry_initial_delay=2.0,  # Forces async_retry to bubble up on first error since 2.0 >= 1.0
+            )
+
+    # action is called once, it fails, async_retry sees delay=2.0 >= max_sleep=1.0, raises.
+    # heartbeat_loop catches it, logs it. It no longer sleeps in the except block!
+    assert action.call_count == 1
+    mock_sleep.assert_not_called()  # We mocked the extra sleep out
+    assert mock_logger.error.called
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_cancelled():
+    action = AsyncMock(side_effect=asyncio.CancelledError("cancelled"))
+
+    run_state = [True]
+
+    def is_running():
+        return run_state.pop(0)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        with pytest.raises(asyncio.CancelledError):
+            await heartbeat_loop(
+                name="test",
+                action=action,
+                is_running=is_running,
+                interval=1.0,
+                jitter_bound=0.5,
+                first_immediate=True,
+            )

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/config.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/config.py
@@ -18,7 +18,7 @@ class JanitorConfig(BaseModel):
     interval: int = 10
     jitter: float = 0.5
     worker_threshold_factor: float = 1.5
-    job_heartbeat_threshold_factor: float = 1.5
+    job_heartbeat_threshold_factor: float = 2.5
     job_assignment_timeout: int = 30
     job_pending_retry_delay: int = 5
     job_pending_timeout: int = 30

--- a/packages/dffmpeg-worker/src/dffmpeg/worker/job.py
+++ b/packages/dffmpeg-worker/src/dffmpeg/worker/job.py
@@ -1,11 +1,11 @@
 import asyncio
 import logging
-import random
 from typing import Callable, Dict, Optional
 
 from ulid import ULID
 
 from dffmpeg.common.http_client import AuthenticatedAsyncClient
+from dffmpeg.common.loop_utils import heartbeat_loop
 from dffmpeg.common.models import (
     JobLogsPayload,
     JobStatusUpdate,
@@ -99,18 +99,22 @@ class JobRunner:
         path = self.coordinator_paths["heartbeat"]
         interval = self.payload.get("heartbeat_interval", 5)
         jitter_bound = min(0.5 * interval, self.config.jitter)
-        while self._running:
-            try:
-                jitter = random.uniform(-jitter_bound, jitter_bound)
-                await asyncio.sleep(max(1, interval + jitter))
 
-                await self.client.post(path)
+        async def _action():
+            resp = await self.client.post(path)
+            logger.debug(f"[{self.client_id}] Sent heartbeat for {self.job_id}")
+            if resp.status_code != 200:
+                logger.warning(f"Job heartbeat failed for {self.job_id}: {resp.status_code} - {resp.text}")
+                resp.raise_for_status()
 
-                logger.debug(f"[{self.client_id}] Sent heartbeat for {self.job_id}")
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.warning(f"[{self.client_id}] Heartbeat failed for {self.job_id}: {e}")
+        await heartbeat_loop(
+            name=f"job heartbeat ({self.job_id})",
+            action=_action,
+            is_running=lambda: getattr(self, "_running", False),
+            interval=float(interval),
+            jitter_bound=jitter_bound,
+            first_immediate=False,
+        )
 
     async def _send_log(self, entry: LogEntry):
         """

--- a/packages/dffmpeg-worker/src/dffmpeg/worker/worker.py
+++ b/packages/dffmpeg-worker/src/dffmpeg/worker/worker.py
@@ -1,12 +1,12 @@
 import asyncio
 import logging
-import random
 from typing import Dict, Optional
 
 import httpx
 from ulid import ULID
 
 from dffmpeg.common.http_client import AuthenticatedAsyncClient
+from dffmpeg.common.loop_utils import heartbeat_loop
 from dffmpeg.common.models import (
     JobRequestMessage,
     JobStatusMessage,
@@ -111,53 +111,52 @@ class Worker:
     async def _registration_loop(self):
         """Periodically registers with the coordinator."""
         jitter_bound = min(0.5 * self.config.registration_interval, self.config.jitter)
-        while self._running:
-            try:
-                # Check and recover mounts
-                await self.mount_manager.refresh_and_recover()
 
-                # Filter paths based on mount status
-                healthy_paths = self.mount_manager.get_healthy_paths(self.config.paths)
+        async def _action():
+            # Check and recover mounts
+            await self.mount_manager.refresh_and_recover()
 
-                # Prepare payload
-                payload_model = WorkerRegistration(
-                    worker_id=self.client_id,
-                    capabilities=[],  # TODO: Retrieve actual capabilities dynamically
-                    binaries=list(self.config.binaries.keys()),
-                    paths=list(healthy_paths.keys()),
-                    supported_transports=self.transport_manager.transport_names,
-                    registration_interval=self.config.registration_interval,
-                    version=WORKER_VERSION,
-                )
+            # Filter paths based on mount status
+            healthy_paths = self.mount_manager.get_healthy_paths(self.config.paths)
 
-                path = self.coordinator_paths["register"]
-                body = payload_model.model_dump(mode="json")
+            # Prepare payload
+            payload_model = WorkerRegistration(
+                worker_id=self.client_id,
+                capabilities=[],  # TODO: Retrieve actual capabilities dynamically
+                binaries=list(self.config.binaries.keys()),
+                paths=list(healthy_paths.keys()),
+                supported_transports=self.transport_manager.transport_names,
+                registration_interval=self.config.registration_interval,
+                version=WORKER_VERSION,
+            )
 
-                resp = await self.client.post(path, json=body)
+            path = self.coordinator_paths["register"]
+            body = payload_model.model_dump(mode="json")
 
-                if resp.status_code == 200:
-                    data = resp.json()
-                    new_transport = data.get("transport")
-                    metadata = data.get("transport_metadata", {})
+            resp = await self.client.post(path, json=body)
 
-                    if new_transport != self.transport_manager.current_transport_name:
-                        logger.info(
-                            f"Transport changed from {self.transport_manager.current_transport_name} to {new_transport}"
-                        )
-                        await self._update_transport(new_transport, metadata)
-                else:
-                    logger.warning(f"Registration failed: {resp.status_code} - {resp.text}")
+            if resp.status_code == 200:
+                data = resp.json()
+                new_transport = data.get("transport")
+                metadata = data.get("transport_metadata", {})
 
-            except asyncio.CancelledError:
-                break
-            except httpx.RequestError as e:
-                logger.warning(f"Registration request failed (network error): {e}")
-            except Exception as e:
-                logger.error(f"Error in registration loop: {e}")
+                if new_transport != self.transport_manager.current_transport_name:
+                    logger.info(
+                        f"Transport changed from {self.transport_manager.current_transport_name} to {new_transport}"
+                    )
+                    await self._update_transport(new_transport, metadata)
+            else:
+                logger.warning(f"Registration failed: {resp.status_code} - {resp.text}")
+                resp.raise_for_status()
 
-            # Sleep with jitter
-            jitter = random.uniform(-jitter_bound, jitter_bound)
-            await asyncio.sleep(max(1, self.config.registration_interval + jitter))
+        await heartbeat_loop(
+            name="registration",
+            action=_action,
+            is_running=lambda: getattr(self, "_running", False),
+            interval=float(self.config.registration_interval),
+            jitter_bound=jitter_bound,
+            first_immediate=True,
+        )
 
     async def _update_transport(self, transport_name: str, metadata: dict):
         """


### PR DESCRIPTION
... and be more forgiving by default for job heartbeats (2.5x instead of 1.5x to allow for a skipped heartbeat and a couple retries on the second attempt)

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #9 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking Changes
- If this is a breaking change, please describe the migration path or dual-mode operation plan.

## Checklist:

### Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that my changes do not introduce new linting errors

### Testing
- [x] I have added tests for critical code paths and functionality
- [x] New and existing unit tests pass locally with my changes

### Architecture & Philosophy
- [x] **Async/Await:** Verified all I/O is non-blocking.
- [x] **Database:** Verified proper handling of database types across engines (e.g., ULID storage as TEXT in SQLite).
- [x] **Statelessness:** Ensured changes align with stateless/path-blind philosophy.
- [x] **Plugins:** If adding a new plugin, confirmed it belongs in the core repo (vs external package).
- [x] **Models:** Used Pydantic V2 for models/config.
