### PR TITLE
Implement 2-step worker registration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ This document outlines the development phases for DFFmpeg, leading up to version
     - [ ] **Coordinator Health Table**: Track coordinator instances in the DB for HA visibility.
     - [x] **Janitor & Cleanup**: Implement on-demand cleanup tasks in Admin CLI (e.g., `dffmpeg-admin janitor clean-jobs`).
     - [x] **Dynamic Binary Validation**: Move allowed binaries list to Coordinator configuration.
-    - [ ] **Transport Handshake Verification (Reachability Check)**: Ensure workers genuinely have a functional transport connection to receive messages rather than just trusting the API registration call.
+    - [x] **Transport Handshake Verification (Reachability Check)**: Ensure workers genuinely have a functional transport connection to receive messages rather than just trusting the API registration call.
 - [x] **Documentation Completion**: Full setup guides, API references, and architecture documentation in `docs/`.
 - [ ] **CLI Consolidation & Refactoring**: Move the vast majority of CLI parsing, formatting, and HTTP API interaction logic into `dffmpeg-common`. `dffmpeg-coordinator` (Admin CLI) and `dffmpeg-client` (Client CLI) packages will primarily provide lightweight entry points. The Admin CLI should eventually evolve to support *all* operations exclusively via the HTTP API, removing reliance on direct database access for operational tasks.
 - [ ] **HTTP Polling Transport Proxy**: Optionally leverage Transport as a backend for HTTP Polling, allowing for Clients/Workers to benefit from message bus notifications, without needing to directly connect to the message bus directly themselves. Useful for cases where the message bus is unreachable by the Workers or Clients directly.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,10 +166,13 @@ graph TD
 ```mermaid
 stateDiagram-v2
     [*] --> Offline
-    Offline --> Online: Register
+    Offline --> Registering: Register
+    Registering --> Online: Transport Handshake Success
+    Registering --> Offline: Handshake Timeout (Janitor)
+    Registering --> Offline: Deregister
     Online --> Offline: Deregister
     Online --> Offline: Timeout (Janitor)
-    Online --> Online: Heartbeat / Activity
+    Online --> Online: Transport Handshake Success
 ```
 
 ### Job Lifecycle

--- a/packages/dffmpeg-common/src/dffmpeg/common/colors.py
+++ b/packages/dffmpeg-common/src/dffmpeg/common/colors.py
@@ -16,6 +16,7 @@ def colorize(text: str, color: str) -> str:
 STATUS_COLORS = {
     "online": Colors.GREEN,
     "offline": Colors.RED,
+    "registering": Colors.YELLOW,
     "running": Colors.BLUE,
     "completed": Colors.GREEN,
     "failed": Colors.RED,

--- a/packages/dffmpeg-common/src/dffmpeg/common/models/__init__.py
+++ b/packages/dffmpeg-common/src/dffmpeg/common/models/__init__.py
@@ -213,7 +213,15 @@ class JobLogsResponse(BaseModel):
     last_message_id: ULID | None = None
 
 
-type MessageType = Literal["job_status", "job_request", "job_logs"]
+class VerifyRegistrationPayload(BaseModel):
+    """
+    Payload for registration verification messages over transport.
+    """
+
+    registration_token: str = Field(min_length=1)
+
+
+type MessageType = Literal["job_status", "job_request", "job_logs", "verify_registration"]
 
 
 class BaseMessage(BaseModel):
@@ -246,11 +254,17 @@ class JobLogsMessage(BaseMessage):
     payload: JobLogsPayload
 
 
+class VerifyRegistrationMessage(BaseMessage):
+    message_type: Literal["verify_registration"] = "verify_registration"
+    payload: VerifyRegistrationPayload
+
+
 type Message = Annotated[
     Union[
         Annotated[JobStatusMessage, Tag("job_status")],
         Annotated[JobRequestMessage, Tag("job_request")],
         Annotated[JobLogsMessage, Tag("job_logs")],
+        Annotated[VerifyRegistrationMessage, Tag("verify_registration")],
     ],
     Discriminator("message_type"),
 ]
@@ -277,7 +291,7 @@ class WorkerBase(BaseModel):
     version: Optional[str] = None
 
 
-type WorkerStatus = Literal["online", "offline", "error"]
+type WorkerStatus = Literal["online", "offline", "error", "registering"]
 
 
 class Worker(WorkerBase):
@@ -304,8 +318,20 @@ class WorkerRegistration(WorkerBase):
     supported_transports: List[str] = Field(min_length=1)
 
 
+class WorkerVerifyRequest(BaseModel):
+    """
+    Payload for worker verification handshake.
+
+    Attributes:
+        registration_token (str): The verification token issued by the coordinator.
+    """
+
+    registration_token: str = Field(min_length=1)
+
+
 class WorkerRecord(Worker, TransportRecord):
-    pass
+    registration_token: Optional[str] = None
+    last_registration_attempt: Optional[datetime] = None
 
 
 class ComponentHealth(BaseModel):

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/admin_cli.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/admin_cli.py
@@ -138,8 +138,9 @@ async def user_set_scope(db: DB, args: argparse.Namespace):
 async def worker_list(db: DB, args: argparse.Namespace):
     window = args.window if hasattr(args, "window") else 3600 * 24
     online = await db.workers.get_workers_by_status("online")
+    registering = await db.workers.get_workers_by_status("registering")
     offline = await db.workers.get_workers_by_status("offline", since_seconds=window)
-    workers = online + offline
+    workers = online + registering + offline
     print_worker_list(workers)
 
 

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/api/routes/dashboard.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/api/routes/dashboard.py
@@ -37,8 +37,9 @@ def format_utc(dt: Optional[datetime]) -> Optional[str]:
 async def get_status_data(window: int, job_repo: JobRepository, worker_repo: WorkerRepository):
     # Use the same window for offline workers as for recent jobs
     online_workers = await worker_repo.get_workers_by_status("online")
+    registering_workers = await worker_repo.get_workers_by_status("registering")
     offline_workers = await worker_repo.get_workers_by_status("offline", since_seconds=window)
-    workers = online_workers + offline_workers
+    workers = online_workers + registering_workers + offline_workers
 
     # Sort workers: Online first, then by last seen (desc), then by ID (asc)
     # Using python sort for simplicity in the route

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/api/routes/worker.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/api/routes/worker.py
@@ -1,14 +1,20 @@
+import asyncio
+import secrets
+from datetime import datetime, timezone
 from logging import getLogger
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 from dffmpeg.common.models import (
     AuthenticatedIdentity,
     TransportRecord,
+    VerifyRegistrationMessage,
+    VerifyRegistrationPayload,
     Worker,
     WorkerDeregistration,
     WorkerRegistration,
+    WorkerVerifyRequest,
 )
 from dffmpeg.coordinator.api.auth import required_hmac_auth
 from dffmpeg.coordinator.api.dependencies import get_config, get_transports, get_worker_repo
@@ -22,9 +28,16 @@ router = APIRouter()
 logger = getLogger(__name__)
 
 
+async def _send_verify_ping(transports: TransportManager, msg: VerifyRegistrationMessage, delay: float = 0.0):
+    if delay > 0:
+        await asyncio.sleep(delay)
+    await transports.send_message(msg)
+
+
 @router.post("/worker/register")
 async def worker_register(
     payload: WorkerRegistration,
+    background_tasks: BackgroundTasks,
     identity: AuthenticatedIdentity = Depends(required_hmac_auth),
     transports: TransportManager = Depends(get_transports),
     worker_repo: WorkerRepository = Depends(get_worker_repo),
@@ -65,16 +78,73 @@ async def worker_register(
     payload_dict = payload.model_dump(mode="python", exclude={"supported_transports"})
     payload_dict["binaries"] = filtered_binaries
 
+    # Check existing worker status
+    # If it was already online, we leave it online, otherwise, it becomes "registering".
+    existing_worker = await worker_repo.get_worker(payload.worker_id)
+    new_status = "online" if (existing_worker and existing_worker.status == "online") else "registering"
+    new_last_seen = existing_worker.last_seen if existing_worker else datetime.now(timezone.utc)
+
+    # Generate the verification token
+    verification_token = secrets.token_urlsafe(32)
+
     record = WorkerRecord(
         **payload_dict,
-        status="online",
+        status=new_status,
         transport=negotiated_transport,
         transport_metadata=transports[negotiated_transport].get_metadata(payload.worker_id),
+        registration_token=verification_token,
+        last_registration_attempt=datetime.now(timezone.utc),
+        last_seen=new_last_seen,
     )
 
     await worker_repo.add_or_update(record)
 
+    # Determine if we should delay the handshake message.
+    delay = 0.0
+    if not (existing_worker and existing_worker.transport == negotiated_transport):
+        delay = config.handshake_delay_seconds
+
+    # Dispatch the verify message in the background, allowing the response to complete first
+    verify_msg = VerifyRegistrationMessage(
+        recipient_id=payload.worker_id, payload=VerifyRegistrationPayload(registration_token=verification_token)
+    )
+    background_tasks.add_task(_send_verify_ping, transports, verify_msg, delay)
+
     return TransportRecord(transport=record.transport, transport_metadata=record.transport_metadata)
+
+
+@router.post("/worker/{worker_id}/verify")
+async def worker_verify(
+    worker_id: str,
+    payload: WorkerVerifyRequest,
+    identity: AuthenticatedIdentity = Depends(required_hmac_auth),
+    worker_repo: WorkerRepository = Depends(get_worker_repo),
+):
+    """
+    Verifies a worker's registration token, completing the handshake and marking it online.
+    """
+    if identity.client_id != worker_id:
+        raise HTTPException(status_code=403, detail="WorkerID does not match authenticated ClientID")
+
+    worker = await worker_repo.get_worker(worker_id)
+    if not worker:
+        raise HTTPException(status_code=404, detail="Worker not found")
+
+    if not worker.registration_token:
+        # It's possible the worker already verified or the token was cleared.
+        raise HTTPException(status_code=400, detail="No pending registration to verify")
+
+    if worker.registration_token != payload.registration_token:
+        raise HTTPException(status_code=400, detail="Invalid registration token")
+
+    # Validation passed. Update state to online, update last_seen, clear token.
+    worker.status = "online"
+    worker.last_seen = datetime.now(timezone.utc)
+    worker.registration_token = None
+
+    await worker_repo.add_or_update(worker)
+
+    return {"status": "ok"}
 
 
 @router.post("/worker/deregister")
@@ -136,11 +206,12 @@ async def list_workers(
     # While the dashboard is unauthenticated, this API returns a lot more information
 
     online = await worker_repo.get_workers_by_status("online")
+    registering = await worker_repo.get_workers_by_status("registering")
     # For offline, maybe limit to recent ones? Or all?
     # Admin CLI limits to 24h. Let's do the same for API to avoid massive lists.
     offline = await worker_repo.get_workers_by_status("offline", since_seconds=window)
 
-    workers = online + offline
+    workers = online + registering + offline
     # Sort by status (online first), then last seen (desc), then ID
     workers.sort(key=lambda w: (w.status != "online", -(w.last_seen.timestamp() if w.last_seen else 0), w.worker_id))
 

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/config.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/config.py
@@ -32,6 +32,7 @@ class CoordinatorConfig(BaseModel):
     transports: TransportConfig = Field(default_factory=TransportConfig)
     janitor: JanitorConfig = Field(default_factory=JanitorConfig)
     default_job_heartbeat_interval: int = default_job_heartbeat_interval
+    handshake_delay_seconds: float = 1.0
     web_dashboard_enabled: bool = True
     allowed_dashboard_ips: List[CIDR] = Field(
         default_factory=lambda: [

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/db/workers/__init__.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/db/workers/__init__.py
@@ -27,6 +27,8 @@ class WorkerRepository(BaseDB):
         Column("transport_metadata", JSON, nullable=False),
         Column("registration_interval", Integer, nullable=False),
         Column("version", String(50), nullable=True),
+        Column("registration_token", String(255), nullable=True),
+        Column("last_registration_attempt", TIMESTAMP(timezone=True), nullable=True),
     )
 
     def __new__(cls, *args, engine: str, **kwargs):

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/db/workers/mysql.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/db/workers/mysql.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import text
+from sqlalchemy import TextClause, text
 
 from dffmpeg.coordinator.db.engines.mysql import MySQLDB
 from dffmpeg.coordinator.db.workers.sqlalchemy import SQLAlchemyWorkerRepository
@@ -16,7 +16,13 @@ class MySQLWorkerRepository(SQLAlchemyWorkerRepository, MySQLDB):
         # Initialize engine
         MySQLDB.__init__(self, tablename=tablename, **kwargs)
 
-    def _get_stale_clause(self, threshold_factor: float, timestamp: datetime):
-        return text("last_seen < DATE_SUB(:ts, INTERVAL (registration_interval * :factor) SECOND)").bindparams(
-            ts=timestamp, factor=threshold_factor
-        )
+    def _get_stale_clauses(self, threshold_factor: float, timestamp: datetime) -> tuple[TextClause, TextClause]:
+        stale_online_clause = text(
+            "last_seen < DATE_SUB(:ts, INTERVAL (registration_interval * :factor) SECOND)"
+        ).bindparams(ts=timestamp, factor=threshold_factor)
+
+        stale_registering_clause = text(
+            "last_registration_attempt < DATE_SUB(:ts, INTERVAL (registration_interval * :factor) SECOND)"
+        ).bindparams(ts=timestamp, factor=threshold_factor)
+
+        return stale_online_clause, stale_registering_clause

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/db/workers/sqlalchemy.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/db/workers/sqlalchemy.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from sqlalchemy import and_, select, update
+from sqlalchemy import TextClause, and_, or_, select, update
 
 from dffmpeg.common.formatting import ensure_utc
 from dffmpeg.common.models import TransportRecord
@@ -28,6 +28,8 @@ class SQLAlchemyWorkerRepository(WorkerRepository, SQLAlchemyDB):
             transport_metadata=parse_json(row["transport_metadata"]),
             registration_interval=row["registration_interval"],
             version=row["version"],
+            registration_token=row["registration_token"],
+            last_registration_attempt=ensure_utc(row["last_registration_attempt"]),
         )
 
     async def get_worker(self, worker_id: str) -> Optional[WorkerRecord]:
@@ -70,8 +72,8 @@ class SQLAlchemyWorkerRepository(WorkerRepository, SQLAlchemyDB):
         rows = await self.get_rows(sql, params)
         return [self._row_to_worker(row) for row in rows]
 
-    def _get_stale_clause(self, threshold_factor: float, timestamp: datetime):
-        raise NotImplementedError("Subclasses must implement _get_stale_clause")
+    def _get_stale_clauses(self, threshold_factor: float, timestamp: datetime) -> tuple[TextClause, TextClause]:
+        raise NotImplementedError("Subclasses must implement _get_stale_clauses")
 
     async def get_stale_workers(
         self, threshold_factor: float = 1.5, timestamp: Optional[datetime] = None
@@ -79,9 +81,14 @@ class SQLAlchemyWorkerRepository(WorkerRepository, SQLAlchemyDB):
         if timestamp is None:
             timestamp = datetime.now(timezone.utc)
 
-        condition = self._get_stale_clause(threshold_factor, timestamp)
+        stale_online_clause, stale_registering_clause = self._get_stale_clauses(threshold_factor, timestamp)
 
-        query = select(self.table).where(and_(self.table.c.status == "online", condition))
+        stale_online = and_(self.table.c.status == "online", stale_online_clause)
+        stale_registering = and_(self.table.c.status == "registering", stale_registering_clause)
+
+        condition = or_(stale_online, stale_registering)
+
+        query = select(self.table).where(condition)
         sql, params = self.compile_query(query)
         rows = await self.get_rows(sql, params)
         return [self._row_to_worker(row) for row in rows]
@@ -104,6 +111,8 @@ class SQLAlchemyWorkerRepository(WorkerRepository, SQLAlchemyDB):
             transport_metadata=safe_worker["transport_metadata"],
             registration_interval=worker_record.registration_interval,
             version=worker_record.version,
+            registration_token=worker_record.registration_token,
+            last_registration_attempt=worker_record.last_registration_attempt,
         )
 
         if exists:

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/db/workers/sqlite.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/db/workers/sqlite.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import text
+from sqlalchemy import TextClause, text
 from sqlalchemy.dialects.sqlite import insert
 
 from dffmpeg.coordinator.db.engines.sqlite import SQLiteDB
@@ -12,10 +12,17 @@ class SQLiteWorkerRepository(SQLAlchemyWorkerRepository, SQLiteDB):
     def __init__(self, *args, path: str, tablename: str = "workers", **kwargs):
         SQLiteDB.__init__(self, path=path, tablename=tablename)
 
-    def _get_stale_clause(self, threshold_factor: float, timestamp: datetime):
-        return text(
+    def _get_stale_clauses(self, threshold_factor: float, timestamp: datetime) -> tuple[TextClause, TextClause]:
+        stale_online_clause = text(
             "datetime(last_seen) < datetime(:ts, '-' || (registration_interval * :factor) || ' seconds')"
         ).bindparams(ts=timestamp, factor=threshold_factor)
+
+        stale_registering_clause = text(
+            "datetime(last_registration_attempt) < "
+            "datetime(:ts, '-' || (registration_interval * :factor) || ' seconds')"
+        ).bindparams(ts=timestamp, factor=threshold_factor)
+
+        return stale_online_clause, stale_registering_clause
 
     async def _upsert_worker(self, worker_record: WorkerRecord):
         # Serialize fields that might contain complex types (like datetime) to be JSON-safe
@@ -34,6 +41,8 @@ class SQLiteWorkerRepository(SQLAlchemyWorkerRepository, SQLiteDB):
                 transport_metadata=safe_worker["transport_metadata"],
                 registration_interval=worker_record.registration_interval,
                 version=worker_record.version,
+                registration_token=worker_record.registration_token,
+                last_registration_attempt=worker_record.last_registration_attempt,
             )
             .on_conflict_do_update(
                 index_elements=["worker_id"],
@@ -47,6 +56,8 @@ class SQLiteWorkerRepository(SQLAlchemyWorkerRepository, SQLiteDB):
                     transport_metadata=safe_worker["transport_metadata"],
                     registration_interval=worker_record.registration_interval,
                     version=worker_record.version,
+                    registration_token=worker_record.registration_token,
+                    last_registration_attempt=worker_record.last_registration_attempt,
                 ),
             )
         )

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/janitor.py
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/janitor.py
@@ -155,7 +155,7 @@ class Janitor:
         """
         stale_workers = await self.worker_repo.get_stale_workers(threshold_factor=self.config.worker_threshold_factor)
         for worker in stale_workers:
-            logger.warning(f"Worker {worker.worker_id} is stale. Marking as offline.")
+            logger.warning(f"Worker {worker.worker_id} is stale (status: {worker.status}). Marking as offline.")
             worker.status = "offline"
             # Clear capabilities and transport info, similar to deregister
             worker.capabilities = []
@@ -165,6 +165,7 @@ class Janitor:
             worker.transport_metadata = {}
             worker.registration_interval = 0
             worker.version = None
+            worker.registration_token = None
             await self.worker_repo.add_or_update(worker)
 
     async def reap_running_jobs(self):

--- a/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/templates/status.html
+++ b/packages/dffmpeg-coordinator/src/dffmpeg/coordinator/templates/status.html
@@ -13,6 +13,7 @@
         tr:nth-child(even) { background-color: #f9f9f9; }
         .status-online { color: green; font-weight: bold; }
         .status-offline { color: red; font-weight: bold; }
+        .status-registering { color: #f39c12; font-weight: bold; } /* Orange/Amber */
         .status-running { color: blue; }
         .status-completed { color: green; }
         .status-failed { color: red; }

--- a/packages/dffmpeg-coordinator/tests/integration/test_smoke.py
+++ b/packages/dffmpeg-coordinator/tests/integration/test_smoke.py
@@ -38,14 +38,29 @@ async def test_worker_registration_and_polling(test_app, sign_request, create_au
             # Verify DB state
             worker = await test_app.state.db.workers.get_worker(worker_id)
             assert worker is not None
+            assert worker.status == "registering"
+            assert worker.registration_token is not None
+
+            # Complete Handshake
+            verify_path = f"/worker/{worker_id}/verify"
+            verify_body = {"registration_token": worker.registration_token}
+            verify_body_str = json.dumps(verify_body)
+            verify_headers = await sign_request(signer, worker_id, "POST", verify_path, verify_body_str)
+
+            resp = await client.post(verify_path, content=verify_body_str, headers=verify_headers)
+            assert resp.status_code == 200
+
+            worker = await test_app.state.db.workers.get_worker(worker_id)
             assert worker.status == "online"
 
-            # 2. Poll for work
+            # 2. Poll for work (we expect to receive the verify_registration message)
             poll_path = "/poll/worker"
             headers = await sign_request(signer, worker_id, "GET", poll_path)
             resp = await client.get(poll_path, headers=headers)
             assert resp.status_code == 200
-            assert resp.json()["messages"] == []
+            messages = resp.json()["messages"]
+            assert len(messages) == 1
+            assert messages[0]["message_type"] == "verify_registration"
 
 
 @pytest.mark.anyio
@@ -80,6 +95,13 @@ async def test_client_job_submission_flow(test_app, sign_request, create_auth_id
                 content=reg_body_str,
                 headers=await sign_request(worker_signer, worker_id, "POST", reg_path, reg_body_str),
             )
+
+            worker = await test_app.state.db.workers.get_worker(worker_id)
+            verify_path = f"/worker/{worker_id}/verify"
+            verify_body = {"registration_token": worker.registration_token}
+            verify_body_str = json.dumps(verify_body)
+            verify_headers = await sign_request(worker_signer, worker_id, "POST", verify_path, verify_body_str)
+            await client.post(verify_path, content=verify_body_str, headers=verify_headers)
 
             # 2. Submit Job
             submit_path = "/jobs/submit"

--- a/packages/dffmpeg-coordinator/tests/unit/test_api_worker_registration.py
+++ b/packages/dffmpeg-coordinator/tests/unit/test_api_worker_registration.py
@@ -1,0 +1,226 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from dffmpeg.common.models import AuthenticatedIdentity, WorkerRegistration, WorkerVerifyRequest
+from dffmpeg.coordinator.api.routes.worker import worker_register, worker_verify
+from dffmpeg.coordinator.config import CoordinatorConfig
+from dffmpeg.coordinator.db.workers import WorkerRecord, WorkerRepository
+from dffmpeg.coordinator.transports import TransportManager
+
+
+@pytest.fixture
+def mock_config():
+    config = CoordinatorConfig()
+    config.allowed_binaries = ["ffmpeg"]
+    config.handshake_delay_seconds = 1.0
+    return config
+
+
+@pytest.fixture
+def mock_deps():
+    return {
+        "identity": AuthenticatedIdentity(client_id="worker_01", role="worker", hmac_key="a" * 44),
+        "transports": AsyncMock(spec=TransportManager),
+        "worker_repo": AsyncMock(spec=WorkerRepository),
+        "background_tasks": MagicMock(),
+    }
+
+
+@pytest.fixture
+def registration_payload():
+    return WorkerRegistration(
+        worker_id="worker_01",
+        capabilities=[],
+        binaries=["ffmpeg"],
+        paths=[],
+        supported_transports=["http_polling"],
+        registration_interval=30,
+        version="1.0.0",
+    )
+
+
+@pytest.mark.anyio
+async def test_worker_register_new_worker(mock_config, mock_deps, registration_payload):
+    # Setup mocks
+    mock_deps["transports"].get_healthy_transports.return_value = {"http_polling"}
+    mock_transport = MagicMock()
+    mock_transport.get_metadata.return_value = {}
+    mock_deps["transports"].__getitem__.return_value = mock_transport
+
+    # Simulate worker not existing yet
+    mock_deps["worker_repo"].get_worker.return_value = None
+
+    # Call the endpoint
+    result = await worker_register(
+        payload=registration_payload,
+        background_tasks=mock_deps["background_tasks"],
+        identity=mock_deps["identity"],
+        transports=mock_deps["transports"],
+        worker_repo=mock_deps["worker_repo"],
+        config=mock_config,
+    )
+
+    assert result.transport == "http_polling"
+
+    # Verify add_or_update was called correctly
+    assert mock_deps["worker_repo"].add_or_update.called
+    record: WorkerRecord = mock_deps["worker_repo"].add_or_update.call_args[0][0]
+
+    assert record.worker_id == "worker_01"
+    assert record.status == "registering"  # Brand new worker is "registering"
+    assert record.registration_token is not None
+    assert record.last_registration_attempt is not None
+
+    # Verify that the ping task was scheduled with the expected delay
+    assert mock_deps["background_tasks"].add_task.called
+    delay_arg = mock_deps["background_tasks"].add_task.call_args[0][3]
+    assert delay_arg == mock_config.handshake_delay_seconds
+
+
+@pytest.mark.anyio
+async def test_worker_register_already_online(mock_config, mock_deps, registration_payload):
+    # Setup mocks
+    mock_deps["transports"].get_healthy_transports.return_value = {"http_polling"}
+    mock_transport = MagicMock()
+    mock_transport.get_metadata.return_value = {}
+    mock_deps["transports"].__getitem__.return_value = mock_transport
+
+    # Simulate an already ONLINE worker
+    existing_worker = WorkerRecord(
+        worker_id="worker_01",
+        status="online",
+        capabilities=[],
+        binaries=[],
+        paths=[],
+        registration_interval=30,
+        transport="http_polling",
+        transport_metadata={},
+        last_seen=datetime.now(timezone.utc),
+    )
+    mock_deps["worker_repo"].get_worker.return_value = existing_worker
+
+    # Call the endpoint
+    await worker_register(
+        payload=registration_payload,
+        background_tasks=mock_deps["background_tasks"],
+        identity=mock_deps["identity"],
+        transports=mock_deps["transports"],
+        worker_repo=mock_deps["worker_repo"],
+        config=mock_config,
+    )
+
+    # Verify add_or_update
+    assert mock_deps["worker_repo"].add_or_update.called
+    record: WorkerRecord = mock_deps["worker_repo"].add_or_update.call_args[0][0]
+
+    assert record.status == "online"  # Worker stays online, no flapping!
+    assert record.registration_token is not None  # But token is still issued
+
+    # Delay should be 0 since transport didn't change
+    delay_arg = mock_deps["background_tasks"].add_task.call_args[0][3]
+    assert delay_arg == 0.0
+
+
+@pytest.mark.anyio
+async def test_worker_verify_success(mock_deps):
+    # Simulate a registering worker waiting for verification
+    pending_worker = WorkerRecord(
+        worker_id="worker_01",
+        status="registering",
+        capabilities=[],
+        binaries=[],
+        paths=[],
+        registration_interval=30,
+        transport="http_polling",
+        transport_metadata={},
+        registration_token="secret_token_123",
+        last_registration_attempt=datetime.now(timezone.utc),
+        last_seen=datetime.now(timezone.utc),
+    )
+    mock_deps["worker_repo"].get_worker.return_value = pending_worker
+
+    payload = WorkerVerifyRequest(registration_token="secret_token_123")
+
+    result = await worker_verify(
+        worker_id="worker_01",
+        payload=payload,
+        identity=mock_deps["identity"],
+        worker_repo=mock_deps["worker_repo"],
+    )
+
+    assert result == {"status": "ok"}
+
+    assert mock_deps["worker_repo"].add_or_update.called
+    updated_record: WorkerRecord = mock_deps["worker_repo"].add_or_update.call_args[0][0]
+
+    assert updated_record.status == "online"
+    assert updated_record.registration_token is None  # Token cleared
+
+
+@pytest.mark.anyio
+async def test_worker_verify_invalid_token(mock_deps):
+    # Simulate a registering worker waiting for verification
+    pending_worker = WorkerRecord(
+        worker_id="worker_01",
+        status="registering",
+        capabilities=[],
+        binaries=[],
+        paths=[],
+        registration_interval=30,
+        transport="http_polling",
+        transport_metadata={},
+        registration_token="secret_token_123",
+        last_registration_attempt=datetime.now(timezone.utc),
+        last_seen=datetime.now(timezone.utc),
+    )
+    mock_deps["worker_repo"].get_worker.return_value = pending_worker
+
+    # Worker sends WRONG token
+    payload = WorkerVerifyRequest(registration_token="wrong_token_456")
+
+    with pytest.raises(HTTPException) as exc:
+        await worker_verify(
+            worker_id="worker_01",
+            payload=payload,
+            identity=mock_deps["identity"],
+            worker_repo=mock_deps["worker_repo"],
+        )
+
+    assert exc.value.status_code == 400
+    assert "Invalid registration token" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_worker_verify_no_token_pending(mock_deps):
+    # Simulate a worker that doesn't have a pending registration
+    # e.g., verified twice or Janitor cleared it
+    worker = WorkerRecord(
+        worker_id="worker_01",
+        status="online",
+        capabilities=[],
+        binaries=[],
+        paths=[],
+        registration_interval=30,
+        transport="http_polling",
+        transport_metadata={},
+        registration_token=None,
+        last_registration_attempt=datetime.now(timezone.utc),
+        last_seen=datetime.now(timezone.utc),
+    )
+    mock_deps["worker_repo"].get_worker.return_value = worker
+
+    payload = WorkerVerifyRequest(registration_token="secret_token_123")
+
+    with pytest.raises(HTTPException) as exc:
+        await worker_verify(
+            worker_id="worker_01",
+            payload=payload,
+            identity=mock_deps["identity"],
+            worker_repo=mock_deps["worker_repo"],
+        )
+
+    assert exc.value.status_code == 400
+    assert "No pending registration" in exc.value.detail

--- a/packages/dffmpeg-coordinator/tests/unit/test_db_workers.py
+++ b/packages/dffmpeg-coordinator/tests/unit/test_db_workers.py
@@ -57,14 +57,48 @@ async def test_get_stale_workers(worker_repo):
         registration_interval=10,
     )
 
+    # Worker 4: Stale Registering (last_registration_attempt 20s ago)
+    worker4 = WorkerRecord(
+        worker_id="worker4",
+        status="registering",
+        last_seen=now - timedelta(seconds=5),  # Should be ignored, using registration attempt instead
+        last_registration_attempt=now - timedelta(seconds=20),
+        capabilities=[],
+        binaries=[],
+        paths=[],
+        transport="http",
+        transport_metadata={},
+        registration_interval=10,
+    )
+
+    # Worker 5: Active Registering (last_registration_attempt 10s ago)
+    worker5 = WorkerRecord(
+        worker_id="worker5",
+        status="registering",
+        last_seen=now - timedelta(seconds=100),  # Should be ignored
+        last_registration_attempt=now - timedelta(seconds=10),
+        capabilities=[],
+        binaries=[],
+        paths=[],
+        transport="http",
+        transport_metadata={},
+        registration_interval=10,
+    )
+
     await worker_repo.add_or_update(worker1)
     await worker_repo.add_or_update(worker2)
     await worker_repo.add_or_update(worker3)
+    await worker_repo.add_or_update(worker4)
+    await worker_repo.add_or_update(worker5)
 
     stale = await worker_repo.get_stale_workers(threshold_factor=1.5, timestamp=now)
+    stale_ids = [w.worker_id for w in stale]
 
-    assert len(stale) == 1
-    assert stale[0].worker_id == "worker1"
+    assert "worker1" in stale_ids
+    assert "worker2" not in stale_ids
+    assert "worker3" not in stale_ids
+    assert "worker4" in stale_ids
+    assert "worker5" not in stale_ids
 
 
 @pytest.mark.anyio

--- a/packages/dffmpeg-coordinator/tests/unit/test_dynamic_binaries.py
+++ b/packages/dffmpeg-coordinator/tests/unit/test_dynamic_binaries.py
@@ -93,6 +93,7 @@ async def test_worker_register_filtering(mock_config, mock_deps):
 
     await worker_register(
         payload=payload,
+        background_tasks=mock_deps["background_tasks"],
         identity=mock_deps["identity"],
         transports=mock_deps["transports"],
         worker_repo=mock_deps["worker_repo"],

--- a/packages/dffmpeg-worker/src/dffmpeg/worker/transport.py
+++ b/packages/dffmpeg-worker/src/dffmpeg/worker/transport.py
@@ -88,12 +88,17 @@ class WorkerTransportManager:
             job_id = getattr(msg, "job_id", getattr(getattr(msg, "payload", None), "job_id", None))
 
             if not job_id:
-                # If it's not a job message (e.g. some future worker-level command), just pass it through
-                # Using the message_id to ensure it doesn't collide with job_ids
-                latest_by_job[str(msg.message_id)] = msg
-                continue
-
-            job_id_str = str(job_id)
+                # If it's not a job message, check if it's a registration verification message.
+                # Registration verification messages should be collapsed to the most recent one.
+                if getattr(msg, "message_type", None) == "verify_registration":
+                    job_id_str = "registration_verify"
+                else:
+                    # If it's not a job message and not a registration verify (e.g. some future worker-level command),
+                    # just pass it through using the message_id to ensure it doesn't collide with job_ids.
+                    latest_by_job[str(msg.message_id)] = msg
+                    continue
+            else:
+                job_id_str = str(job_id)
 
             if job_id_str not in latest_by_job:
                 latest_by_job[job_id_str] = msg

--- a/packages/dffmpeg-worker/src/dffmpeg/worker/worker.py
+++ b/packages/dffmpeg-worker/src/dffmpeg/worker/worker.py
@@ -12,8 +12,10 @@ from dffmpeg.common.models import (
     JobStatusMessage,
     JobStatusUpdate,
     JobStatusUpdateStatus,
+    VerifyRegistrationMessage,
     WorkerDeregistration,
     WorkerRegistration,
+    WorkerVerifyRequest,
 )
 from dffmpeg.common.version import get_package_version
 from dffmpeg.worker.config import WorkerConfig
@@ -61,9 +63,13 @@ class Worker:
         self._registration_task: Optional[asyncio.Task] = None
         self._transport_task: Optional[asyncio.Task] = None
 
+        self._verified_event = asyncio.Event()
+        self._verification_timeout_task: Optional[asyncio.Task] = None
+
         self.coordinator_paths = {
             "register": "/worker/register",
             "deregister": "/worker/deregister",
+            "verify": f"/worker/{self.client_id}/verify",
         }
 
         self._active_jobs: Dict[ULID, JobRunner] = {}
@@ -145,6 +151,15 @@ class Worker:
                         f"Transport changed from {self.transport_manager.current_transport_name} to {new_transport}"
                     )
                     await self._update_transport(new_transport, metadata)
+
+                # We registered, now wait for the verification message over the transport
+                self._verified_event.clear()
+
+                if self._verification_timeout_task:
+                    self._verification_timeout_task.cancel()
+
+                self._verification_timeout_task = asyncio.create_task(self._verification_timeout())
+
             else:
                 logger.warning(f"Registration failed: {resp.status_code} - {resp.text}")
                 resp.raise_for_status()
@@ -157,6 +172,19 @@ class Worker:
             jitter_bound=jitter_bound,
             first_immediate=True,
         )
+
+    async def _verification_timeout(self, timeout: float = 15.0):
+        """Waits for verification. If it times out, tears down the transport to force a retry."""
+        try:
+            await asyncio.wait_for(self._verified_event.wait(), timeout=timeout)
+            logger.info(f"[{self.client_id}] Handshake verification completed successfully.")
+        except asyncio.TimeoutError:
+            logger.error(
+                f"[{self.client_id}] Did not receive verification message within {timeout}s. Tearing down transport."
+            )
+            await self._stop_transport()
+        except asyncio.CancelledError:
+            pass
 
     async def _update_transport(self, transport_name: str, metadata: dict):
         """
@@ -198,10 +226,30 @@ class Worker:
                         await self._handle_job_request(message)
                     elif isinstance(message, JobStatusMessage):
                         await self._handle_job_status(message)
+                    elif isinstance(message, VerifyRegistrationMessage):
+                        await self._handle_verify_registration(message)
                     else:
                         logger.debug(f"Ignored message type: {message.message_type}")
         except Exception as e:
             logger.error(f"Transport listener error: {e}")
+
+    async def _handle_verify_registration(self, message: VerifyRegistrationMessage):
+        """
+        Handles the verification message from the coordinator.
+        """
+        token = message.payload.registration_token
+        logger.info(f"[{self.client_id}] Received verification token via transport. Echoing to coordinator...")
+
+        try:
+            payload = WorkerVerifyRequest(registration_token=token)
+            path = self.coordinator_paths["verify"]
+
+            resp = await self.client.post(path, json=payload.model_dump(mode="json"))
+            resp.raise_for_status()
+
+            self._verified_event.set()
+        except Exception as e:
+            logger.error(f"[{self.client_id}] Failed to echo verification token: {e}")
 
     async def _handle_job_request(self, message: JobRequestMessage):
         """

--- a/packages/dffmpeg-worker/tests/unit/test_worker_registration.py
+++ b/packages/dffmpeg-worker/tests/unit/test_worker_registration.py
@@ -1,0 +1,91 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dffmpeg.common.models import VerifyRegistrationMessage, VerifyRegistrationPayload
+from dffmpeg.worker.config import WorkerConfig
+from dffmpeg.worker.worker import Worker
+
+
+@pytest.fixture
+def mock_config():
+    config = WorkerConfig(client_id="worker_01", hmac_key="testkey", registration_interval=10)
+    config.coordinator.host = "127.0.0.1"
+    config.coordinator.port = 8000
+    config.coordinator.scheme = "http"
+    return config
+
+
+@pytest.fixture
+def worker(mock_config):
+    with (
+        patch("dffmpeg.worker.worker.AuthenticatedAsyncClient") as mock_client_cls,
+        patch("dffmpeg.worker.worker.WorkerTransportManager") as mock_tm_cls,
+    ):
+
+        mock_client = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        mock_tm = AsyncMock()
+        mock_tm.current_transport_name = "http_polling"
+        mock_tm_cls.return_value = mock_tm
+
+        worker = Worker(config=mock_config)
+        # Prevent the registration loop from actually running
+        worker._running = False
+
+        yield worker
+
+
+@pytest.mark.anyio
+async def test_handle_verify_registration_success(worker):
+    token = "secret_token_abc"
+    msg = VerifyRegistrationMessage(
+        recipient_id=worker.client_id, payload=VerifyRegistrationPayload(registration_token=token)
+    )
+
+    # Mock a successful post to /verify
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
+    worker.client.post.return_value = mock_resp
+
+    # Ensure the event starts cleared
+    assert not worker._verified_event.is_set()
+
+    # Trigger the handler
+    await worker._handle_verify_registration(msg)
+
+    # Assert API was called correctly
+    worker.client.post.assert_called_once()
+    call_args = worker.client.post.call_args
+    assert call_args[0][0] == worker.coordinator_paths["verify"]
+    assert call_args[1]["json"] == {"registration_token": token}
+
+    # Assert event was set
+    assert worker._verified_event.is_set()
+
+
+@pytest.mark.anyio
+async def test_verification_timeout_triggers_teardown(worker):
+    worker._stop_transport = AsyncMock()
+
+    # Call the timeout method with a very short timeout
+    await worker._verification_timeout(timeout=0.01)
+
+    # It should have timed out and called stop_transport
+    assert worker._stop_transport.called
+
+
+@pytest.mark.anyio
+async def test_verification_timeout_success_aborts_teardown(worker):
+    worker._stop_transport = AsyncMock()
+
+    # We set the event immediately before or during the wait to simulate success
+    worker._verified_event.set()
+
+    # Call the timeout method
+    await worker._verification_timeout(timeout=0.01)
+
+    # Since it was verified, it should NOT tear down the transport
+    assert not worker._stop_transport.called

--- a/packages/dffmpeg-worker/tests/unit/test_worker_transport_manager.py
+++ b/packages/dffmpeg-worker/tests/unit/test_worker_transport_manager.py
@@ -4,7 +4,14 @@ from unittest.mock import AsyncMock
 import pytest
 from ulid import ULID
 
-from dffmpeg.common.models import JobRequestMessage, JobRequestPayload, JobStatusMessage, JobStatusPayload
+from dffmpeg.common.models import (
+    JobRequestMessage,
+    JobRequestPayload,
+    JobStatusMessage,
+    JobStatusPayload,
+    VerifyRegistrationMessage,
+    VerifyRegistrationPayload,
+)
 from dffmpeg.common.transports import ClientTransportConfig
 from dffmpeg.worker.transport import WorkerTransportManager
 
@@ -91,6 +98,35 @@ def test_collapse_batch_filters_multiple_jobs():
     assert msg_b1 in collapsed
     assert msg_a2 in collapsed
     assert msg_a1 not in collapsed
+
+
+def test_collapse_batch_filters_registration_pings():
+    """
+    Test that multiple registration verification messages are collapsed
+    to the most recent one.
+    """
+    msg1 = VerifyRegistrationMessage(
+        message_id=M_ULIDS[0],
+        recipient_id="worker1",
+        payload=VerifyRegistrationPayload(registration_token="token1"),
+    )
+    msg2 = VerifyRegistrationMessage(
+        message_id=M_ULIDS[1],
+        recipient_id="worker1",
+        payload=VerifyRegistrationPayload(registration_token="token2"),
+    )
+    msg3 = VerifyRegistrationMessage(
+        message_id=M_ULIDS[2],
+        recipient_id="worker1",
+        payload=VerifyRegistrationPayload(registration_token="token3"),
+    )
+
+    messages = [msg1, msg2, msg3]
+    collapsed = WorkerTransportManager.collapse_batch(messages)
+
+    # We expect them to be collapsed to exactly 1 (the latest).
+    assert len(collapsed) == 1
+    assert collapsed[0] == msg3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
This prevents workers from being marked "Online" if they fail to connect to the working transport or cannot successfully receive messages through it for some reason. In this case, they will stay in "registering" state and not be marked "Online" (and available for assignment). This does make initial registration and transition to "Online" slightly longer, but re-registrations (while they also take slightly longer now as well) don't transition out of "online" during that part of the process, so impact is negligible, except that workers can now be transitioned out of "Online" if their transports start failing, which will then push them into the "registering" state once the worker attempts to register again.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking Changes
As-is, this will require workers and coordinators to be updated together.

It was considered to add a flag for enabling/requiring the transport ping verification step, allowing workers to be updated first, THEN the coordinators. Or adding config to disable to feature on the coordinator before update.

HOWEVER, as we're in beta, it was decided to skip this complexity in favor of "just upgrade everything together and take a small service outage" (and given the target of homelabs rather than huge high-traffic deployments, this seems "acceptable" for right now). This is NOT a long-term strategy, but pre-1.0, it was decided to skip the added complexity of making this togglable and optional simply to support transitions/updates.

## Checklist:

### Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that my changes do not introduce new linting errors

### Testing
- [x] I have added tests for critical code paths and functionality
- [x] New and existing unit tests pass locally with my changes

### Architecture & Philosophy
- [x] **Async/Await:** Verified all I/O is non-blocking.
- [x] **Database:** Verified proper handling of database types across engines (e.g., ULID storage as TEXT in SQLite).
- [x] **Statelessness:** Ensured changes align with stateless/path-blind philosophy.
- [x] **Plugins:** If adding a new plugin, confirmed it belongs in the core repo (vs external package).
- [x] **Models:** Used Pydantic V2 for models/config.
